### PR TITLE
Set MIME Type to JAVASCRIPT

### DIFF
--- a/google_sheets_test/Sheets_Macro.txt
+++ b/google_sheets_test/Sheets_Macro.txt
@@ -6,7 +6,7 @@ function doGet(request) {
   var range = SpreadsheetApp.openById(SPREADSHEET_ID).getSheetByName(SHEET_NAME).getDataRange();
   var json = callback + '(' + Utilities.jsonStringify(range.getValues()) + ')';
   
-  return ContentService.createTextOutput(json).setMimeType(ContentService.MimeType.JSON);
+  return ContentService.createTextOutput(json).setMimeType(ContentService.MimeType.JAVASCRIPT);
 }
 
 function testDoGet(){


### PR DESCRIPTION
I was able to recreate your error when `return ContentService.createTextOutput(json).setMimeType(ContentService.MimeType.JSON)`

When I changed it to `return ContentService.createTextOutput(json).setMimeType(ContentService.MimeType.JAVASCRIPT)`, the map worked.

I'm not 100% confident about why, but here's my hunch. This macro, is being added to the map as JavaScript. Then the function runs and returns JSON.Thus, when your browser tries to pull in the macro when the MIME type is set to JSON, it gets confused because it's not getting JSON. Rather, it's getting JavaScript.

This may be totally wrong, but I got the same error you had when